### PR TITLE
fix basicauth provider tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.go]
+indent_style = tab

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,5 @@ install:
 script:
   - go build github.com/janekolszak/idp/example/idp
   - go test github.com/janekolszak/idp/helpers
+  - go test github.com/janekolszak/idp/providers/basic
   - go test github.com/janekolszak/idp/providers/cookie

--- a/providers/basic/basic-auth.go
+++ b/providers/basic/basic-auth.go
@@ -31,6 +31,7 @@ func NewBasicAuth(htpasswdFileName string, realm string) (*BasicAuth, error) {
 func (c *BasicAuth) Check(r *http.Request) (user string, err error) {
 	user, pass, ok := r.BasicAuth()
 	if !ok {
+		user = ""
 		err = core.ErrorAuthenticationFailure
 		return
 	}
@@ -39,12 +40,14 @@ func (c *BasicAuth) Check(r *http.Request) (user string, err error) {
 	if err != nil {
 		// Prevent timing attack
 		bcrypt.CompareHashAndPassword([]byte{}, []byte(pass))
+		user = ""
 		err = core.ErrorAuthenticationFailure
 		return
 	}
 
 	err = bcrypt.CompareHashAndPassword([]byte(hash), []byte(pass))
 	if err != nil {
+		user = ""
 		err = core.ErrorAuthenticationFailure
 	}
 

--- a/providers/basic/htpasswd_test.go
+++ b/providers/basic/htpasswd_test.go
@@ -8,31 +8,31 @@ import (
 )
 
 const (
-	testFileName = "/tmp/idp_htpasswd_test"
-	htpasswdFile = `# Comment
-	                user1:hash
-	                user2:hash
-	                user3:hash
-	                user4:hash`
+	htpasswdTestFileName = "/tmp/idp_htpasswd_test"
+	htpasswdFileContents = `# Comment
+							user1:hash
+							user2:hash
+							user3:hash
+							user4:hash`
 )
 
-var users = []string{"user1", "user2", "user3", "user4"}
+var htpasswdUsers = []string{"user1", "user2", "user3", "user4"}
 
 func TestHtpasswd(t *testing.T) {
 	assert := assert.New(t)
 
 	// Prepare file
-	err := ioutil.WriteFile(testFileName, []byte(htpasswdFile), 0644)
+	err := ioutil.WriteFile(htpasswdTestFileName, []byte(htpasswdFileContents), 0644)
 	assert.Nil(err)
 
 	// Load passwords
 	var h Htpasswd
 
-	err = h.Load(testFileName)
+	err = h.Load(htpasswdTestFileName)
 	assert.Nil(err)
 
 	// t.Log("index:", len(h.(map[string]string)))
-	for _, user := range users {
+	for _, user := range htpasswdUsers {
 		hash, err := h.Get(user)
 		assert.Nil(err)
 		assert.Equal(hash, "hash", "Bad password")


### PR DESCRIPTION
small one, just noticed the basicauth tests were broken for two reasons:

- not returning empty user string in case of error condition
- htpasswd tests broken by my last refactor

I've added the travis update too, and stuck in .editorconfig to hopefully prevent annoying whitespace updates in future.